### PR TITLE
i2c_esp32: fix clock source search and ADC adjust unit ID for hal 5.1

### DIFF
--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -319,7 +319,7 @@ static const struct adc_driver_api api_esp32_driver_api = {
 #define ESP32_ADC_INIT(inst)							\
 										\
 	static const struct adc_esp32_conf adc_esp32_conf_##inst = {		\
-		.unit = DT_PROP(DT_DRV_INST(inst), unit),			\
+		.unit = DT_PROP(DT_DRV_INST(inst), unit) - 1,			\
 		.channel_count = DT_PROP(DT_DRV_INST(inst), channel_count),	\
 	};									\
 										\

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -134,7 +134,7 @@ static i2c_clock_source_t i2c_get_clk_src(uint32_t clk_freq)
 {
 	i2c_clock_source_t clk_srcs[] = SOC_I2C_CLKS;
 
-	for (size_t i = 0; i < ARRAY_SIZE(clk_srcs) / sizeof(clk_srcs[0]); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(clk_srcs); i++) {
 		/* I2C SCL clock frequency should not larger than clock source frequency/20 */
 		if (clk_freq <= (i2c_get_src_clk_freq(clk_srcs[i]) / 20)) {
 			return clk_srcs[i];


### PR DESCRIPTION
Change array iteration loop to search the entire array instead of the array / 4.